### PR TITLE
Added: PYSPARK_ALLOW_INSECURE_GATEWAY=1 to polynote-spark-python

### DIFF
--- a/polynotes/polynote-spark-python/Dockerfile
+++ b/polynotes/polynote-spark-python/Dockerfile
@@ -32,4 +32,6 @@ ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 RUN apt-get install -y python3 python3-dev python3-pip \
     && pip3 install jep jedi pyspark virtualenv numpy pandas
 
+ENV PYSPARK_ALLOW_INSECURE_GATEWAY=1
+
 CMD ["/bin/bash", "/polynote/polynote"]


### PR DESCRIPTION
Added: `PYSPARK_ALLOW_INSECURE_GATEWAY=1` to `polynote-spark-python` to share variable between Scala and Python