### PR TITLE
Changed: back to Scala 2.11 as Spark 2.4.4 requires Scala 2.11

### DIFF
--- a/polynotes/polynote-python/Dockerfile
+++ b/polynotes/polynote-python/Dockerfile
@@ -10,9 +10,9 @@ ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-jdk-hotspot
 
 ENV POLYNOTE_VERSION=0.2.11
 
-RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist-2.12.tar.gz \
-    && tar -zxvf polynote-dist-2.12.tar.gz \
-    && rm polynote-dist-2.12.tar.gz
+RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist.tar.gz \
+    && tar -zxvf polynote-dist.tar.gz \
+    && rm polynote-dist.tar.gz
 
 COPY polynotes/polynote-python/config.yml /polynote/config.yml
 

--- a/polynotes/polynote-python/README.md
+++ b/polynotes/polynote-python/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 * Polynote: `0.2.11`
-* Scala: `2.12`
+* Scala: `2.11`
 
 ## Pull the polynote image
   ```bash

--- a/polynotes/polynote-spark-python/Dockerfile
+++ b/polynotes/polynote-spark-python/Dockerfile
@@ -10,9 +10,9 @@ ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-jdk-hotspot
 
 ENV POLYNOTE_VERSION=0.2.11
 
-RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist-2.12.tar.gz \
-    && tar -zxvf polynote-dist-2.12.tar.gz \
-    && rm polynote-dist-2.12.tar.gz
+RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist.tar.gz \
+    && tar -zxvf polynote-dist.tar.gz \
+    && rm polynote-dist.tar.gz
 
 COPY polynotes/polynote-spark-python/config.yml /polynote/config.yml
 

--- a/polynotes/polynote-spark-python/README.md
+++ b/polynotes/polynote-spark-python/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 * Polynote: `0.2.11`
-* Scala: `2.12`
+* Scala: `2.11`
 
 It is Polynote with Spark supporting both Scala and Python. It also has `NumPy` and `pandas`.
 

--- a/polynotes/polynote-spark/Dockerfile
+++ b/polynotes/polynote-spark/Dockerfile
@@ -10,9 +10,9 @@ ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-jdk-hotspot
 
 ENV POLYNOTE_VERSION=0.2.11
 
-RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist-2.12.tar.gz \
-    && tar -zxvf polynote-dist-2.12.tar.gz \
-    && rm polynote-dist-2.12.tar.gz
+RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist.tar.gz \
+    && tar -zxvf polynote-dist.tar.gz \
+    && rm polynote-dist.tar.gz
 
 COPY polynotes/polynote-spark/config.yml /polynote/config.yml
 

--- a/polynotes/polynote-spark/README.md
+++ b/polynotes/polynote-spark/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 * Polynote: `0.2.11`
-* Scala: `2.12`
+* Scala: `2.11`
 
 It is Polynote without Spark supporting both Scala and Python. It also has `NumPy` and `pandas`.
 

--- a/polynotes/polynote/Dockerfile
+++ b/polynotes/polynote/Dockerfile
@@ -10,9 +10,9 @@ ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-jdk-hotspot
 
 ENV POLYNOTE_VERSION=0.2.11
 
-RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist-2.12.tar.gz \
-    && tar -zxvf polynote-dist-2.12.tar.gz \
-    && rm polynote-dist-2.12.tar.gz
+RUN wget https://github.com/polynote/polynote/releases/download/${POLYNOTE_VERSION}/polynote-dist.tar.gz \
+    && tar -zxvf polynote-dist.tar.gz \
+    && rm polynote-dist.tar.gz
 
 COPY polynotes/polynote/config.yml /polynote/config.yml
 

--- a/polynotes/polynote/README.md
+++ b/polynotes/polynote/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 * Polynote: `0.2.11`
-* Scala: `2.12`
+* Scala: `2.11`
 
 ## Pull the polynote image
   ```bash


### PR DESCRIPTION
Changed: back to Scala 2.11 as Spark 2.4.4 requires Scala 2.11