### PR TITLE
Update s for java 8 and 11

### DIFF
--- a/sbt/java11/Dockerfile
+++ b/sbt/java11/Dockerfile
@@ -1,21 +1,23 @@
-FROM ubuntu:20.04
-
-ARG SBT_VERSION_ARG=1.5.1
+FROM ubuntu:22.04
 
 RUN apt-get update \
-  && apt-get install -y wget gnupg2 apt-transport-https software-properties-common vim git-core
+  && apt-get install -y --no-install-recommends curl wget gnupg2 apt-transport-https software-properties-common vim git-core
 
-RUN UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
-  && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
-  && echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/adoptopenjdk.list \
-  && apt-get update \
-  && apt-get install -y adoptopenjdk-11-hotspot
+RUN mkdir -p /etc/apt/keyrings \
+  && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+  && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
+  && apt update
+  
+RUN apt install -y temurin-11-jdk \
+  && export JAVA_HOME=/usr/lib/jvm/temurin-11-jdk-$(dpkg --print-architecture)
 
-ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64
+ARG SBT_VERSION_ARG=1.8.2
+
 ENV SBT_VERSION=$SBT_VERSION_ARG
 
 RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
   && dpkg -i sbt-$SBT_VERSION.deb \
   && rm sbt-$SBT_VERSION.deb \
   && which sbt \
-  && cd /tmp && sbt sbtVersion
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/java11/README.md
+++ b/sbt/java11/README.md
@@ -1,5 +1,10 @@
 # sbt + Java 11 (AdoptOpenJDK11)
 
+* Build Locally
+```shell
+docker build -t k3vin/sbt-java11:latest .
+```
+
 * Pull the image
   ```
   docker pull k3vin/sbt-java11

--- a/sbt/java8/Dockerfile
+++ b/sbt/java8/Dockerfile
@@ -1,21 +1,23 @@
-FROM ubuntu:20.04
-
-ARG SBT_VERSION_ARG=1.5.1
+FROM ubuntu:22.04
 
 RUN apt-get update \
-  && apt-get install -y wget gnupg2 apt-transport-https software-properties-common vim git-core
+  && apt-get install -y --no-install-recommends curl wget gnupg2 apt-transport-https software-properties-common vim git-core
 
-RUN UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
-  && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
-  && echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/adoptopenjdk.list \
-  && apt-get update \
-  && apt-get install -y adoptopenjdk-8-hotspot
+RUN mkdir -p /etc/apt/keyrings \
+  && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+  && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
+  && apt update
 
-ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+RUN apt install -y temurin-8-jdk \
+  && export JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-$(dpkg --print-architecture)
+
+ARG SBT_VERSION_ARG=1.8.2
+
 ENV SBT_VERSION=$SBT_VERSION_ARG
 
 RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
   && dpkg -i sbt-$SBT_VERSION.deb \
   && rm sbt-$SBT_VERSION.deb \
   && which sbt \
-  && cd /tmp && sbt sbtVersion
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/java8/README.md
+++ b/sbt/java8/README.md
@@ -1,5 +1,10 @@
 # sbt + Java 8 (AdoptOpenJDK8)
 
+* Build Locally
+```shell
+docker build -t k3vin/sbt-java8:latest .
+```
+
 * Pull the image
   ```
   docker pull k3vin/sbt-java8


### PR DESCRIPTION
Update s for java 8 and 11
- Upgrade Ubuntu from 20.04 to 22.04
- Upgrade sbt from 1.5.1 to 1.8.2
- adoptopenjdk => adoptium
- Update repository info