### PR TITLE
Fix #28 - [node] Docker run fails to find node in non-interactive shells

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -18,3 +18,11 @@ RUN export NVM_DIR="$HOME/.nvm" \
   && nvm install $NODE_18_VERSION_ARG \
   && nvm install $NODE_19_VERSION_ARG \
   && nvm alias default $DEFAULT_NODE_VERSION_ARG
+
+# Create a script to source nvm.sh
+RUN echo 'source $HOME/.nvm/nvm.sh' > /root/env_setup.sh
+
+# Set BASH_ENV to source the env_setup.sh script in non-interactive shells
+ENV BASH_ENV=/root/env_setup.sh
+
+CMD ["/bin/bash"]

--- a/node/README.md
+++ b/node/README.md
@@ -2,12 +2,12 @@
 
 * Build locally
   ```shell
-  docker build -t node:main .
+  docker build -t node:local .
   ```
 
 * Run locally in interactive mode
   ```shell
-  docker run -i -t node bash
+  docker run -i -t node:local bash
   ```
 
 * Pull the image


### PR DESCRIPTION
Fix #28 - [node] Docker run fails to find node in non-interactive shells