### PR TITLE
Add codecov to multiple Dockerfiles and Update Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -289,6 +289,97 @@ jobs:
         run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
 
 
+  build-sbt-codecov:
+    needs: build-sbt
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+          - { name: "sbt-java8-codecov",  path: "sbt/java8-codecov" }
+          - { name: "sbt-java11-codecov", path: "sbt/java11-codecov" }
+          - { name: "sbt-java17-codecov", path: "sbt/java17-codecov" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.0.3
+        with:
+          cosign-release: 'v1.13.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.2.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2.8.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.6.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+
   build-sbt-jekyll:
     needs: build-sbt
 

--- a/sbt/java11-codecov/Dockerfile
+++ b/sbt/java11-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java11:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/java11-codecov/README.md
+++ b/sbt/java11-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 11 (Adoptium) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java11-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java11-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java11-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java11-codecov:main bash
+  ```

--- a/sbt/java17-codecov/Dockerfile
+++ b/sbt/java17-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java17:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/java17-codecov/README.md
+++ b/sbt/java17-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 17 (Adoptium) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java17-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java17-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java17-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java17-codecov:main bash
+  ```

--- a/sbt/java8-codecov/Dockerfile
+++ b/sbt/java8-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java8:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/java8-codecov/README.md
+++ b/sbt/java8-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 8 (Adoptium) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java8-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java8-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java8-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java8-codecov:main bash
+  ```


### PR DESCRIPTION
Add codecov to multiple Dockerfiles and Update Docker publish workflow
Created Dockerfiles to install codecov in sbt with java8, java11, and java17 environments and updated the Docker publish workflow accordingly to build the codecov Docker images. Also, added README for each version's instruction. Required for assessing code coverage in these respective environments.