### PR TITLE
Update docker-publish workflow to handle more tag patterns

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v*.*.*', 'v*.*', 'v*' ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Update docker-publish workflow to handle more tag patterns
The tagging pattern in the docker-publish workflow has been expanded to include `'v*.*'` and `'v*'`, in addition to the existing `'v*.*.*'`. This allows for greater flexibility in version tagging, accommodating different styles used across various projects.