### PR TITLE
Add README for kevin-docker project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# kevin-docker
+
+## v1
+`v1` contains Docker image with sbt `1.8.2`.


### PR DESCRIPTION
Add README for kevin-docker project
A README.md file was created for the project 'kevin-docker'. This includes the version details of the Docker image used (sbt 1.8.2 in v1). This addition is meant to provide a summary and version details of the project to visitors and developers.