### PR TITLE
Update Dockerfile to include apt update before install

### DIFF
--- a/sbt/java11-jekyll/Dockerfile
+++ b/sbt/java11-jekyll/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/kevin-lee/sbt-java11:main
 
-RUN apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
   && gem install jekyll bundler

--- a/sbt/java17-jekyll/Dockerfile
+++ b/sbt/java17-jekyll/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/kevin-lee/sbt-java17:main
 
-RUN apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
   && gem install jekyll bundler

--- a/sbt/java8-jekyll/Dockerfile
+++ b/sbt/java8-jekyll/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/kevin-lee/sbt-java8:main
 
-RUN apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
   && gem install jekyll bundler


### PR DESCRIPTION
Update Dockerfile to include apt update before install
The Dockerfiles for `sbt/java17-jekyll`, `sbt/java8-jekyll`, and `sbt/java11-jekyll` have been updated to include `apt update` before running the `apt-get install` command. This ensures that the package lists for upgrades and new package installations are always up-to-date before we start installing anything, preventing possible issues due to outdated package references.