### PR TITLE
Add v2 description to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 ## v1
 `v1` contains Docker image with sbt `1.8.2`.
+
+## v2
+`v2` contains Docker image with sbt `1.8.3`.


### PR DESCRIPTION
Add v2 description to README.md
This commit expands the README.md to include information about the new Docker image version v2. Specifically, it details that v2 utilises sbt `1.8.3`, differing from v1 which uses sbt `1.8.2`. This offers clarity to users about the differences between the versions. [skip ci]