### PR TITLE
Add `v3` description to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 
 ## v2
 `v2` contains Docker image with sbt `1.8.3`.
+
+## v3
+`v3` contains Docker image with sbt `1.9.0`.


### PR DESCRIPTION
Add `v3` description to `README.md`
A version 3(`v3`) description has been added to the `README.md` file. This version contains a Docker image with sbt `1.9.0`.