### PR TITLE
Update SBT version from 1.9.0 to 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@
 
 ## v3
 `v3` contains Docker image with sbt `1.9.0`.
+
+## v4
+`v4` contains Docker image with sbt `1.9.1`.


### PR DESCRIPTION
Added v4 details to `README.md`
- Updated `README` to include newly created 'v4', which comes along with SBT version upgrade from '1.9.0' to '1.9.1'.