### PR TITLE
Close #116 - Add Docker images with BellSoft Liberica JDK

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -383,6 +383,98 @@ jobs:
         run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
 
 
+  build-sbt-liberica:
+    needs: build-java-liberica
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+          - { name: "sbt-java8-liberica",  path: "sbt/liberica/java8" }
+          - { name: "sbt-java11-liberica", path: "sbt/liberica/java11" }
+          - { name: "sbt-java17-liberica", path: "sbt/liberica/java17" }
+          - { name: "sbt-java21-liberica", path: "sbt/liberica/java21" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.0.3
+        with:
+          cosign-release: 'v1.13.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.1.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.4.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+
   build-sbt-temurin-codecov:
     needs: build-sbt-temurin
 
@@ -401,6 +493,98 @@ jobs:
           - { name: "sbt-java11-temurin-codecov", path: "sbt/temurin/java11-codecov" }
           - { name: "sbt-java17-temurin-codecov", path: "sbt/temurin/java17-codecov" }
           - { name: "sbt-java21-temurin-codecov", path: "sbt/temurin/java21-codecov" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.0.3
+        with:
+          cosign-release: 'v1.13.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.1.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.4.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+
+  build-sbt-liberica-codecov:
+    needs: build-sbt-liberica
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+          - { name: "sbt-java8-liberica-codecov",  path: "sbt/liberica/java8-codecov" }
+          - { name: "sbt-java11-liberica-codecov", path: "sbt/liberica/java11-codecov" }
+          - { name: "sbt-java17-liberica-codecov", path: "sbt/liberica/java17-codecov" }
+          - { name: "sbt-java21-liberica-codecov", path: "sbt/liberica/java21-codecov" }
 
     steps:
       - name: Checkout repository
@@ -565,3 +749,96 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+
+  build-sbt-liberica-jekyll:
+    needs: build-sbt-liberica
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+          - { name: "sbt-java8-liberica-jekyll",  path: "sbt/liberica/java8-jekyll" }
+          - { name: "sbt-java11-liberica-jekyll", path: "sbt/liberica/java11-jekyll" }
+          - { name: "sbt-java17-liberica-jekyll", path: "sbt/liberica/java17-jekyll" }
+          - { name: "sbt-java21-liberica-jekyll", path: "sbt/liberica/java21-jekyll" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.0.3
+        with:
+          cosign-release: 'v1.13.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.1.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.4.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+

--- a/sbt/liberica/java11-codecov/Dockerfile
+++ b/sbt/liberica/java11-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java11-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/liberica/java11-codecov/README.md
+++ b/sbt/liberica/java11-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 11 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java11-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java11-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java11-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java11-liberica-codecov:main bash
+  ```

--- a/sbt/liberica/java11-jekyll/Dockerfile
+++ b/sbt/liberica/java11-jekyll/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/kevin-lee/sbt-java11-liberica:main
+
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+  && gem install jekyll bundler

--- a/sbt/liberica/java11-jekyll/README.md
+++ b/sbt/liberica/java11-jekyll/README.md
@@ -1,0 +1,11 @@
+# Node + Java 11 (Liberica JDK) + SBT + Jekyll
+
+* Pull the image
+  ```
+  docker pull ghcr.io/kevin-lee/sbt-java11-liberica-jekyll:main
+  ```
+
+* Run in interactive mode
+  ```
+  docker run -i -t ghcr.io/kevin-lee/sbt-java11-liberica-jekyll:main bash
+  ```

--- a/sbt/liberica/java11/Dockerfile
+++ b/sbt/liberica/java11/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/kevin-lee/java11-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
+  && dpkg -i sbt-$SBT_VERSION.deb \
+  && rm sbt-$SBT_VERSION.deb \
+  && which sbt \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/liberica/java11/README.md
+++ b/sbt/liberica/java11/README.md
@@ -1,0 +1,21 @@
+# Node + Java 11 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t sbt-java11-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java11-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java11-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java11-liberica:main bash
+  ```

--- a/sbt/liberica/java17-codecov/Dockerfile
+++ b/sbt/liberica/java17-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java17-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/liberica/java17-codecov/README.md
+++ b/sbt/liberica/java17-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 17 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java17-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java17-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java17-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java17-liberica-codecov:main bash
+  ```

--- a/sbt/liberica/java17-jekyll/Dockerfile
+++ b/sbt/liberica/java17-jekyll/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/kevin-lee/sbt-java17-liberica:main
+
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+  && gem install jekyll bundler

--- a/sbt/liberica/java17-jekyll/README.md
+++ b/sbt/liberica/java17-jekyll/README.md
@@ -1,0 +1,11 @@
+# Node + Java 17 (Liberica JDK) + SBT + Jekyll
+
+* Pull the image
+  ```
+  docker pull ghcr.io/kevin-lee/sbt-java17-liberica-jekyll:main
+  ```
+
+* Run in interactive mode
+  ```
+  docker run -i -t ghcr.io/kevin-lee/sbt-java17-liberica-jekyll:main bash
+  ```

--- a/sbt/liberica/java17/Dockerfile
+++ b/sbt/liberica/java17/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/kevin-lee/java17-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
+  && dpkg -i sbt-$SBT_VERSION.deb \
+  && rm sbt-$SBT_VERSION.deb \
+  && which sbt \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/liberica/java17/README.md
+++ b/sbt/liberica/java17/README.md
@@ -1,0 +1,21 @@
+# Node + Java 17 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t sbt-java17-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java17-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java17-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java17-liberica:main bash
+  ```

--- a/sbt/liberica/java21-codecov/Dockerfile
+++ b/sbt/liberica/java21-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java21-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/liberica/java21-codecov/README.md
+++ b/sbt/liberica/java21-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java21-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java21-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java21-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java21-liberica-codecov:main bash
+  ```

--- a/sbt/liberica/java21-jekyll/Dockerfile
+++ b/sbt/liberica/java21-jekyll/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/kevin-lee/sbt-java21-liberica:main
+
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+  && gem install jekyll bundler

--- a/sbt/liberica/java21-jekyll/README.md
+++ b/sbt/liberica/java21-jekyll/README.md
@@ -1,0 +1,11 @@
+# Node + Java 21 (Liberica JDK) + SBT + Jekyll
+
+* Pull the image
+  ```
+  docker pull ghcr.io/kevin-lee/sbt-java21-liberica-jekyll:main
+  ```
+
+* Run in interactive mode
+  ```
+  docker run -i -t ghcr.io/kevin-lee/sbt-java21-liberica-jekyll:main bash
+  ```

--- a/sbt/liberica/java21/Dockerfile
+++ b/sbt/liberica/java21/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/kevin-lee/java21-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
+  && dpkg -i sbt-$SBT_VERSION.deb \
+  && rm sbt-$SBT_VERSION.deb \
+  && which sbt \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/liberica/java21/README.md
+++ b/sbt/liberica/java21/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t sbt-java21-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java21-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java21-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java21-liberica:main bash
+  ```

--- a/sbt/liberica/java8-codecov/Dockerfile
+++ b/sbt/liberica/java8-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/sbt-java8-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && shasum -a 256 -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/sbt/liberica/java8-codecov/README.md
+++ b/sbt/liberica/java8-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 8 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t sbt-java8-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java8-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java8-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java8-liberica-codecov:main bash
+  ```

--- a/sbt/liberica/java8-jekyll/Dockerfile
+++ b/sbt/liberica/java8-jekyll/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/kevin-lee/sbt-java8-liberica:main
+
+RUN apt update \
+  && apt-get install -y apt-utils nodejs npm fakeroot ruby-full build-essential zlib1g-dev \
+  && gem install jekyll bundler

--- a/sbt/liberica/java8-jekyll/README.md
+++ b/sbt/liberica/java8-jekyll/README.md
@@ -1,0 +1,11 @@
+# sbt + Java 8 (AdoptOpenJDK8)
+
+* Pull the image
+  ```
+  docker pull ghcr.io/kevin-lee/sbt-java8-liberica-jekyll:main
+  ```
+
+* Run in interactive mode
+  ```
+  docker run -i -t ghcr.io/kevin-lee/sbt-java8-liberica-jekyll:main bash
+  ```

--- a/sbt/liberica/java8/Dockerfile
+++ b/sbt/liberica/java8/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/kevin-lee/java8-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-$SBT_VERSION.deb https://scala.jfrog.io/artifactory/debian/sbt-$SBT_VERSION.deb \
+  && dpkg -i sbt-$SBT_VERSION.deb \
+  && rm sbt-$SBT_VERSION.deb \
+  && which sbt \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/sbt/liberica/java8/README.md
+++ b/sbt/liberica/java8/README.md
@@ -1,0 +1,21 @@
+# Node + Java 8 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t sbt-java8-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t sbt-java8-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/sbt-java8-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/sbt-java8-liberica:main bash
+  ```


### PR DESCRIPTION
Close #116 - Add Docker images with BellSoft Liberica JDK
Add
- `sbt/liberica/java8`
- `sbt/liberica/java8-codecov`
- `sbt/liberica/java8-jekyll`
- `sbt/liberica/java11`
- `sbt/liberica/java11-codecov`
- `sbt/liberica/java11-jekyll`
- `sbt/liberica/java17`
- `sbt/liberica/java17-codecov`
- `sbt/liberica/java17-jekyll`
- `sbt/liberica/java21`
- `sbt/liberica/java21-codecov`
- `sbt/liberica/java21-jekyll`