### PR TITLE
Fix GitHib Actions: fix incorrect setting in `build-alpine-java-liberica`

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -940,7 +940,7 @@ jobs:
 
 
   build-alpine-java-liberica:
-    needs: build-ubuntu-node
+    needs: build-alpine-node
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fix GitHib Actions: fix incorrect setting in `build-alpine-java-liberica`