### PR TITLE
Fix #185 - Docker build for Temurin Java 8 on Alpine Linux is broken for ARM architecture

### DIFF
--- a/alpine/java/temurin/java8/Dockerfile
+++ b/alpine/java/temurin/java8/Dockerfile
@@ -2,18 +2,31 @@ FROM ghcr.io/kevin-lee/alpine-node:main
 
 ARG JAVA_VERSION=8
 
-# Download the Eclipse Adoptium RSA key
-RUN wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk \
-  # Configure the Eclipse Adoptium APK repository
-  && echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories \
-  # Install the required Temurin version
-  && apk update && apk add "temurin-${JAVA_VERSION}-jdk"
+# Install Java 8 based on architecture
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        # Install Temurin for x86_64 \
+        echo "Installing Temurin for AMD64..." && \
+        wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk && \
+        echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories && \
+        apk update && apk add "temurin-${JAVA_VERSION}-jdk"; \
+    else \
+        # Install Alpine OpenJDK for ARM64 and other architectures (Temurin not available) \
+        echo "Installing Alpine OpenJDK for ARM64..." && \
+        apk update && apk add openjdk${JAVA_VERSION}-jdk; \
+    fi
 
 # Verify installation
 RUN java -version
 
-# Set JAVA_HOME environment variable
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-temurin
+# Set JAVA_HOME and PATH to work with both installations
+# The system will use whichever Java installation is present
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+RUN if [ -d "/usr/lib/jvm/java-${JAVA_VERSION}-temurin" ]; then \
+        ln -sf /usr/lib/jvm/java-${JAVA_VERSION}-temurin /usr/lib/jvm/default-jvm; \
+    else \
+        ln -sf /usr/lib/jvm/java-${JAVA_VERSION}-openjdk /usr/lib/jvm/default-jvm; \
+    fi
 
 # Set PATH environment variable
 ENV PATH="${JAVA_HOME}/bin:${PATH}"


### PR DESCRIPTION
Fix #185 - Docker build for Temurin Java 8 on Alpine Linux is broken for ARM architecture

---
Fix: Handle architecture-specific Java 8 installation for Alpine

Eclipse Adoptium provides temurin-8-jdk for x86_64 but not for ARM64/aarch64 in APK format. This change implements architecture detection to install the optimal Java distribution for each platform:

- x86_64: Install Eclipse Temurin 8 from Adoptium APK repository
- ARM64/aarch64: Install OpenJDK 8 from Alpine's community repository

Changes:
- Add architecture detection (uname -m) during package installation
- Install temurin-8-jdk for x86_64 with Adoptium repository setup
- Install openjdk8-jdk for ARM64 using Alpine's native packages
- Create symlink to /usr/lib/jvm/default-jvm for unified JAVA_HOME
- Update JAVA_HOME and PATH to work with both installations

Resolves build error on ARM64: `temurin-8-jdk` (no such package)