### PR TITLE
Fix #185 - Docker build for Temurin Java 8 on Alpine Linux is broken for ARM architecture

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1045,7 +1045,7 @@ jobs:
     strategy:
       matrix:
         docker:
-          - { name: "alpine-java8-temurin",  path: "alpine/java/temurin/java8", platforms: "linux/amd64" }
+          - { name: "alpine-java8-temurin",  path: "alpine/java/temurin/java8", platforms: "linux/amd64,linux/arm64" }
           - { name: "alpine-java11-temurin", path: "alpine/java/temurin/java11", platforms: "linux/amd64" }
           - { name: "alpine-java17-temurin", path: "alpine/java/temurin/java17", platforms: "linux/amd64" }
           - { name: "alpine-java21-temurin", path: "alpine/java/temurin/java21", platforms: "linux/amd64,linux/arm64" }


### PR DESCRIPTION
Fix #185 - Docker build for Temurin Java 8 on Alpine Linux is broken for ARM architecture

---
Update: GitHub Actions workflow
- Add linux/arm64 to platforms list for alpine-java8-temurin build
- Enables multi-architecture support for Java 8 Temurin Alpine image