### PR TITLE
Close #161 - Add a Docker image with SBT + Jdk 21 installed on Alpine Linux

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1140,7 +1140,7 @@ jobs:
           - { name: "alpine-sbt-java8-liberica",  path: "alpine/sbt/liberica/java8" }
 #          - { name: "alpine-sbt-java11-liberica", path: "alpine/sbt/liberica/java11" }
 #          - { name: "alpine-sbt-java17-liberica", path: "alpine/sbt/liberica/java17" }
-#          - { name: "alpine-sbt-java21-liberica", path: "alpine/sbt/liberica/java21" }
+          - { name: "alpine-sbt-java21-liberica", path: "alpine/sbt/liberica/java21" }
 
     steps:
       - name: Checkout repository
@@ -1232,7 +1232,7 @@ jobs:
           - { name: "alpine-sbt-java8-temurin",  path: "alpine/sbt/temurin/java8" }
 #          - { name: "alpine-sbt-java11-temurin", path: "alpine/sbt/temurin/java11" }
 #          - { name: "alpine-sbt-java17-temurin", path: "alpine/sbt/temurin/java17" }
-#          - { name: "alpine-sbt-java21-temurin", path: "alpine/sbt/temurin/java21" }
+          - { name: "alpine-sbt-java21-temurin", path: "alpine/sbt/temurin/java21" }
 
     steps:
       - name: Checkout repository

--- a/alpine/sbt/liberica/java21/Dockerfile
+++ b/alpine/sbt/liberica/java21/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/kevin-lee/alpine-java21-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-${SBT_VERSION}.tgz https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz \
+  && tar -xvzf sbt-${SBT_VERSION}.tgz -C /usr/lib/ \
+  && ln -s /usr/lib/sbt/bin/sbt /usr/local/bin/sbt \
+  && which sbt \
+  && rm sbt-${SBT_VERSION}.tgz \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/alpine/sbt/liberica/java21/README.md
+++ b/alpine/sbt/liberica/java21/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java21-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java21-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java21-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java21-liberica:main bash
+  ```

--- a/alpine/sbt/temurin/java21/Dockerfile
+++ b/alpine/sbt/temurin/java21/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/kevin-lee/alpine-java21-temurin:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-${SBT_VERSION}.tgz https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz \
+  && tar -xvzf sbt-${SBT_VERSION}.tgz -C /usr/lib/ \
+  && ln -s /usr/lib/sbt/bin/sbt /usr/local/bin/sbt \
+  && which sbt \
+  && rm sbt-${SBT_VERSION}.tgz \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/alpine/sbt/temurin/java21/README.md
+++ b/alpine/sbt/temurin/java21/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Adoptium) + SBT
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java21-temurin:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java21-temurin:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java21-temurin:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java21-temurin:main bash
+  ```


### PR DESCRIPTION
Close #161 - Add a Docker image with SBT + Jdk 21 installed on Alpine Linux

---
Add sbt support for Java 21 on Alpine Linux

- Enable `alpine-sbt-java21-liberica` and `alpine-sbt-java21-temurin` builds in CI workflow
- Add Dockerfile for Alpine + Java 21 Liberica + sbt 1.9.9
- Add Dockerfile for Alpine + Java 21 Temurin + sbt 1.9.9
- Include README documentation for both new Docker images