### PR TITLE
Fix #195: Docker build for Temurin Java 11 on Alpine Linux is broken for ARM architecture

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1046,7 +1046,7 @@ jobs:
       matrix:
         docker:
           - { name: "alpine-java8-temurin",  path: "alpine/java/temurin/java8", platforms: "linux/amd64,linux/arm64" }
-          - { name: "alpine-java11-temurin", path: "alpine/java/temurin/java11", platforms: "linux/amd64" }
+          - { name: "alpine-java11-temurin", path: "alpine/java/temurin/java11", platforms: "linux/amd64,linux/arm64" }
           - { name: "alpine-java17-temurin", path: "alpine/java/temurin/java17", platforms: "linux/amd64" }
           - { name: "alpine-java21-temurin", path: "alpine/java/temurin/java21", platforms: "linux/amd64,linux/arm64" }
 

--- a/alpine/java/temurin/java11/Dockerfile
+++ b/alpine/java/temurin/java11/Dockerfile
@@ -2,18 +2,31 @@ FROM ghcr.io/kevin-lee/alpine-node:main
 
 ARG JAVA_VERSION=11
 
-# Download the Eclipse Adoptium RSA key
-RUN wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk \
-  # Configure the Eclipse Adoptium APK repository
-  && echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories \
-  # Install the required Temurin version
-  && apk update && apk add "temurin-${JAVA_VERSION}-jdk"
+# Install Java 11 based on architecture
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        # Install Temurin for x86_64 \
+        echo "Installing Temurin for AMD64..." && \
+        wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk && \
+        echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories && \
+        apk update && apk add "temurin-${JAVA_VERSION}-jdk"; \
+    else \
+        # Install Alpine OpenJDK for ARM64 and other architectures (Temurin not available) \
+        echo "Installing Alpine OpenJDK for ARM64..." && \
+        apk update && apk add openjdk${JAVA_VERSION}-jdk; \
+    fi
 
 # Verify installation
 RUN java -version
 
-# Set JAVA_HOME environment variable
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-temurin
+# Set JAVA_HOME and PATH to work with both installations
+# The system will use whichever Java installation is present
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+RUN if [ -d "/usr/lib/jvm/java-${JAVA_VERSION}-temurin" ]; then \
+        ln -sf /usr/lib/jvm/java-${JAVA_VERSION}-temurin /usr/lib/jvm/default-jvm; \
+    else \
+        ln -sf /usr/lib/jvm/java-${JAVA_VERSION}-openjdk /usr/lib/jvm/default-jvm; \
+    fi
 
 # Set PATH environment variable
 ENV PATH="${JAVA_HOME}/bin:${PATH}"


### PR DESCRIPTION
Fix #195: Docker build for Temurin Java 11 on Alpine Linux is broken for ARM architecture

Add multi-architecture support for `alpine-java11-temurin`

- Add architecture detection for `x86_64` vs `arm64` in Java 11 Alpine image
- Install Temurin JDK for AMD64 (`x86_64`) architecture
- Fallback to Alpine OpenJDK for ARM64 (`arm64`) and other architectures
- Create unified `JAVA_HOME` symlink for architecture-independent paths