### PR TITLE
Close #159: Add a Docker image with SBT + Jdk 11 installed on Alpine Linux

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1138,7 +1138,7 @@ jobs:
       matrix:
         docker:
           - { name: "alpine-sbt-java8-liberica",  path: "alpine/sbt/liberica/java8" }
-#          - { name: "alpine-sbt-java11-liberica", path: "alpine/sbt/liberica/java11" }
+          - { name: "alpine-sbt-java11-liberica", path: "alpine/sbt/liberica/java11" }
 #          - { name: "alpine-sbt-java17-liberica", path: "alpine/sbt/liberica/java17" }
           - { name: "alpine-sbt-java21-liberica", path: "alpine/sbt/liberica/java21" }
 
@@ -1230,7 +1230,7 @@ jobs:
       matrix:
         docker:
           - { name: "alpine-sbt-java8-temurin",  path: "alpine/sbt/temurin/java8" }
-#          - { name: "alpine-sbt-java11-temurin", path: "alpine/sbt/temurin/java11" }
+          - { name: "alpine-sbt-java11-temurin", path: "alpine/sbt/temurin/java11" }
 #          - { name: "alpine-sbt-java17-temurin", path: "alpine/sbt/temurin/java17" }
           - { name: "alpine-sbt-java21-temurin", path: "alpine/sbt/temurin/java21" }
 

--- a/alpine/sbt/liberica/java11/Dockerfile
+++ b/alpine/sbt/liberica/java11/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/kevin-lee/alpine-java11-liberica:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-${SBT_VERSION}.tgz https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz \
+  && tar -xvzf sbt-${SBT_VERSION}.tgz -C /usr/lib/ \
+  && ln -s /usr/lib/sbt/bin/sbt /usr/local/bin/sbt \
+  && which sbt \
+  && rm sbt-${SBT_VERSION}.tgz \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/alpine/sbt/liberica/java11/README.md
+++ b/alpine/sbt/liberica/java11/README.md
@@ -1,0 +1,21 @@
+# Node + Java 11 (Liberica JDK) + SBT
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java11-liberica:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java11-liberica:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java11-liberica:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java11-liberica:main bash
+  ```

--- a/alpine/sbt/temurin/java11/Dockerfile
+++ b/alpine/sbt/temurin/java11/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/kevin-lee/alpine-java11-temurin:main
+
+ARG SBT_VERSION_ARG=1.9.9
+
+ENV SBT_VERSION=$SBT_VERSION_ARG
+
+RUN curl -L -o sbt-${SBT_VERSION}.tgz https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz \
+  && tar -xvzf sbt-${SBT_VERSION}.tgz -C /usr/lib/ \
+  && ln -s /usr/lib/sbt/bin/sbt /usr/local/bin/sbt \
+  && which sbt \
+  && rm sbt-${SBT_VERSION}.tgz \
+  && mkdir -p /tmp/test-sbt && cd /tmp/test-sbt \
+  && sbt --batch sbtVersion && cd /tmp && rm -R /tmp/test-sbt

--- a/alpine/sbt/temurin/java11/README.md
+++ b/alpine/sbt/temurin/java11/README.md
@@ -1,0 +1,21 @@
+# Node + Java 11 (Adoptium) + SBT
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java11-temurin:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java11-temurin:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java11-temurin:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java11-temurin:main bash
+  ```


### PR DESCRIPTION
Close #159: Add a Docker image with SBT + Jdk 11 installed on Alpine Linux

- Add Dockerfile for Alpine + Java 11 Liberica + sbt 1.9.9
- Add Dockerfile for Alpine + Java 11 Temurin + sbt 1.9.9
- Include README documentation for both new Docker images