### PR TITLE
Close #213: Fix `JAVA_HOME` for Liberica JRE 21 on Alpine Linux

### DIFF
--- a/alpine/java/liberica/java21-jre/Dockerfile
+++ b/alpine/java/liberica/java21-jre/Dockerfile
@@ -4,10 +4,12 @@ ARG JAVA_VERSION=21
 
 RUN echo "https://apk.bell-sw.com/main" | tee -a /etc/apk/repositories \
     && wget -P /etc/apk/keys/ https://apk.bell-sw.com/info@bell-sw.com-5fea454e.rsa.pub \
-    && apk add "bellsoft-java${JAVA_VERSION}-runtime"
+    && apk add "bellsoft-java${JAVA_VERSION}-runtime" \
+    && rm /usr/lib/jvm/default-jvm \
+    && ln -s /usr/lib/jvm/bellsoft-java${JAVA_VERSION}-runtime /usr/lib/jvm/default-jvm
 
 RUN java -version
 
-ENV JAVA_HOME=/usr/lib/jvm/bellsoft-java${JAVA_VERSION}
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 
 ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/alpine/java/liberica/java21-jre/README.md
+++ b/alpine/java/liberica/java21-jre/README.md
@@ -1,4 +1,4 @@
-# Node + Java 21 (Liberica JDK)
+# Node + Java 21 (Liberica JRE)
 
 * Build locally
   ```shell


### PR DESCRIPTION
Close #213: Fix `JAVA_HOME` for Liberica JRE 21 on Alpine Linux