### PR TITLE
Update Temurin documentation to use proper Eclipse Temurin branding

### DIFF
--- a/alpine/java/temurin/java11/README.md
+++ b/alpine/java/temurin/java11/README.md
@@ -1,4 +1,4 @@
-# Node + Java 11 (Adoptium)
+# Node + Java 11 (Eclipse Temurin)
 
 * Build locally
   ```shell

--- a/alpine/java/temurin/java17-jre/README.md
+++ b/alpine/java/temurin/java17-jre/README.md
@@ -1,4 +1,4 @@
-# Node + Java 17 (Adoptium)
+# Node + Java 17 (Eclipse Temurin JRE)
 
 * Build locally
   ```shell

--- a/alpine/java/temurin/java17/README.md
+++ b/alpine/java/temurin/java17/README.md
@@ -1,4 +1,4 @@
-# Node + Java 17 (Adoptium)
+# Node + Java 17 (Eclipse Temurin)
 
 * Build locally
   ```shell

--- a/alpine/java/temurin/java21-jre/README.md
+++ b/alpine/java/temurin/java21-jre/README.md
@@ -1,4 +1,4 @@
-# Node + Java 21 (Adoptium)
+# Node + Java 21 (Eclipse Temurin JRE)
 
 * Build locally
   ```shell

--- a/alpine/java/temurin/java21/README.md
+++ b/alpine/java/temurin/java21/README.md
@@ -1,4 +1,4 @@
-# Node + Java 21 (Adoptium)
+# Node + Java 21 (Eclipse Temurin)
 
 * Build locally
   ```shell

--- a/alpine/java/temurin/java8/README.md
+++ b/alpine/java/temurin/java8/README.md
@@ -1,4 +1,4 @@
-# Node + Java 8 (Adoptium)
+# Node + Java 8 (Eclipse Temurin)
 
 * Build locally
   ```shell

--- a/alpine/sbt/temurin/java11/README.md
+++ b/alpine/sbt/temurin/java11/README.md
@@ -1,4 +1,4 @@
-# Node + Java 11 (Adoptium) + SBT
+# Node + Java 11 (Eclipse Temurin) + SBT
 
 * Build locally
   ```shell

--- a/alpine/sbt/temurin/java17/README.md
+++ b/alpine/sbt/temurin/java17/README.md
@@ -1,4 +1,4 @@
-# Node + Java 17 (Adoptium) + SBT
+# Node + Java 17 (Eclipse Temurin) + SBT
 
 * Build locally
   ```shell

--- a/alpine/sbt/temurin/java21/README.md
+++ b/alpine/sbt/temurin/java21/README.md
@@ -1,4 +1,4 @@
-# Node + Java 21 (Adoptium) + SBT
+# Node + Java 21 (Eclipse Temurin) + SBT
 
 * Build locally
   ```shell

--- a/alpine/sbt/temurin/java8/README.md
+++ b/alpine/sbt/temurin/java8/README.md
@@ -1,4 +1,4 @@
-# Node + Java 8 (Adoptium) + SBT
+# Node + Java 8 (Eclipse Temurin) + SBT
 
 * Build locally
   ```shell


### PR DESCRIPTION
Update Temurin documentation to use proper Eclipse Temurin branding

- Replace "Adoptium" references with "Eclipse Temurin" in README titles
- Add "JRE" suffix to JRE-specific variants for clarity