### PR TITLE
Close #243: Add an sbt Docker image with Java 21 and Codecov support for both Alpine Linux and Ubuntu Linux

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1315,3 +1315,187 @@ jobs:
         run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
 
 
+  build-alpine-sbt-temurin-codecov:
+    needs: build-alpine-sbt-temurin
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+#          - { name: "alpine-sbt-java8-temurin-codecov",  path: "alpine/sbt/temurin/java8-codecov" }
+#          - { name: "alpine-sbt-java11-temurin-codecov", path: "alpine/sbt/temurin/java11-codecov" }
+#          - { name: "alpine-sbt-java17-temurin-codecov", path: "alpine/sbt/temurin/java17-codecov" }
+          - { name: "alpine-sbt-java21-temurin-codecov", path: "alpine/sbt/temurin/java21-codecov" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.9.2
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+
+  build-alpine-sbt-liberica-codecov:
+    needs: build-alpine-sbt-liberica
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    strategy:
+      matrix:
+        docker:
+#          - { name: "alpine-sbt-java8-liberica-codecov",  path: "alpine/sbt/liberica/java8-codecov" }
+#          - { name: "alpine-sbt-java11-liberica-codecov", path: "alpine/sbt/liberica/java11-codecov" }
+#          - { name: "alpine-sbt-java17-liberica-codecov", path: "alpine/sbt/liberica/java17-codecov" }
+          - { name: "alpine-sbt-java21-liberica-codecov", path: "alpine/sbt/liberica/java21-codecov" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.9.2
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Repository Owner to Lowercase
+        id: repo_owner
+        run: |
+          REPOSITORY_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPOSITORY_OWNER_LOWER=$REPOSITORY_OWNER_LOWER" >> $GITHUB_ENV
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER_LOWER }}/${{ matrix.docker.name }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.docker.name }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image (${{ matrix.docker.path }})
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.docker.path }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }}
+          cache-to: type=gha,scope=${{ env.GITHUB_REF_NAME }}-${{ matrix.docker.name }},mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.build-and-push.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+

--- a/alpine/sbt/liberica/java21-codecov/Dockerfile
+++ b/alpine/sbt/liberica/java21-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java21-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/liberica/java21-codecov/README.md
+++ b/alpine/sbt/liberica/java21-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java21-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java21-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java21-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java21-liberica-codecov:main bash
+  ```

--- a/alpine/sbt/temurin/java21-codecov/Dockerfile
+++ b/alpine/sbt/temurin/java21-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java21-temurin:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/temurin/java21-codecov/README.md
+++ b/alpine/sbt/temurin/java21-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 21 (Eclipse Temurin) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java21-temurin-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java21-temurin-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java21-temurin-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java21-temurin-codecov:main bash
+  ```


### PR DESCRIPTION
Close #243: Add an sbt Docker image with Java 21 and Codecov support for both Alpine Linux and Ubuntu Linux

Add Codecov integration to Java 21 SBT Docker images

- Add `alpine/sbt/liberica/java21-codecov` with Codecov uploader
- Add `alpine/sbt/temurin/java21-codecov` with Codecov uploader
- Include GPG verification and SHA256 checksum validation for security
- Add comprehensive README documentation for both variants