### PR TITLE
Close #244: Add an sbt Docker image with Java 17 and Codecov support for both Alpine Linux and Ubuntu Linux

### DIFF
--- a/alpine/sbt/liberica/java17-codecov/Dockerfile
+++ b/alpine/sbt/liberica/java17-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java17-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/liberica/java17-codecov/README.md
+++ b/alpine/sbt/liberica/java17-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 17 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java17-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java17-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java17-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java17-liberica-codecov:main bash
+  ```

--- a/alpine/sbt/temurin/java17-codecov/Dockerfile
+++ b/alpine/sbt/temurin/java17-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java17-temurin:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/temurin/java17-codecov/README.md
+++ b/alpine/sbt/temurin/java17-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 17 (Eclipse Temurin) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java17-temurin-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java17-temurin-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java17-temurin-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java17-temurin-codecov:main bash
+  ```


### PR DESCRIPTION
Close #244: Add an sbt Docker image with Java 17 and Codecov support for both Alpine Linux and Ubuntu Linux

Add Codecov integration to Java 17 SBT Docker images

- Add `alpine/sbt/liberica/java17-codecov` with Codecov uploader
- Add `alpine/sbt/temurin/java17-codecov` with Codecov uploader
- Include GPG verification and SHA256 checksum validation for security
- Add comprehensive README documentation for both variants