### PR TITLE
Close #246: Add an sbt Docker image with Java 8 and Codecov support for both Alpine Linux and Ubuntu Linux

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1329,7 +1329,7 @@ jobs:
     strategy:
       matrix:
         docker:
-#          - { name: "alpine-sbt-java8-temurin-codecov",  path: "alpine/sbt/temurin/java8-codecov" }
+          - { name: "alpine-sbt-java8-temurin-codecov",  path: "alpine/sbt/temurin/java8-codecov" }
           - { name: "alpine-sbt-java11-temurin-codecov", path: "alpine/sbt/temurin/java11-codecov" }
           - { name: "alpine-sbt-java17-temurin-codecov", path: "alpine/sbt/temurin/java17-codecov" }
           - { name: "alpine-sbt-java21-temurin-codecov", path: "alpine/sbt/temurin/java21-codecov" }
@@ -1421,7 +1421,7 @@ jobs:
     strategy:
       matrix:
         docker:
-#          - { name: "alpine-sbt-java8-liberica-codecov",  path: "alpine/sbt/liberica/java8-codecov" }
+          - { name: "alpine-sbt-java8-liberica-codecov",  path: "alpine/sbt/liberica/java8-codecov" }
           - { name: "alpine-sbt-java11-liberica-codecov", path: "alpine/sbt/liberica/java11-codecov" }
           - { name: "alpine-sbt-java17-liberica-codecov", path: "alpine/sbt/liberica/java17-codecov" }
           - { name: "alpine-sbt-java21-liberica-codecov", path: "alpine/sbt/liberica/java21-codecov" }

--- a/alpine/sbt/liberica/java8-codecov/Dockerfile
+++ b/alpine/sbt/liberica/java8-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java8-liberica:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/liberica/java8-codecov/README.md
+++ b/alpine/sbt/liberica/java8-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 8 (Liberica JDK) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java8-liberica-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java8-liberica-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java8-liberica-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java8-liberica-codecov:main bash
+  ```

--- a/alpine/sbt/temurin/java8-codecov/Dockerfile
+++ b/alpine/sbt/temurin/java8-codecov/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/kevin-lee/alpine-sbt-java8-temurin:main
+
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.kbx --import \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM \
+  && curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig \
+  && gpg --no-default-keyring --keyring trustedkeys.kbx --verify codecov.SHA256SUM.sig codecov.SHA256SUM \
+  && sha256sum -c codecov.SHA256SUM \
+  && chmod +x codecov

--- a/alpine/sbt/temurin/java8-codecov/README.md
+++ b/alpine/sbt/temurin/java8-codecov/README.md
@@ -1,0 +1,21 @@
+# Node + Java 8 (Eclipse Temurin) + SBT + Codecov
+
+* Build locally
+  ```shell
+  docker build -t alpine-sbt-java8-temurin-codecov:local .
+  ```
+
+* Run locally in interactive mode
+  ```shell
+  docker run -i -t alpine-sbt-java8-temurin-codecov:local bash
+  ```
+
+* Pull the image
+  ```shell
+  docker pull ghcr.io/kevin-lee/alpine-sbt-java8-temurin-codecov:main
+  ```
+
+* Run in interactive mode
+  ```shell
+  docker run -i -t ghcr.io/kevin-lee/alpine-sbt-java8-temurin-codecov:main bash
+  ```


### PR DESCRIPTION
Close #246: Add an sbt Docker image with Java 8 and Codecov support for both Alpine Linux and Ubuntu Linux

Add Codecov integration to Java 8 SBT Docker images

- Add `alpine/sbt/liberica/java8-codecov` with Codecov uploader
- Add `alpine/sbt/temurin/java8-codecov` with Codecov uploader
- Include GPG verification and SHA256 checksum validation for security
- Add comprehensive README documentation for both variants